### PR TITLE
Standardize remote auth and always list tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,41 @@ Useful for development — runs the server from a local clone of this repository
 }
 ```
 
+### Running as a remote HTTP server (self-hosting)
+
+The server also supports the MCP streamable-HTTP transport. Start it with:
+
+```bash
+MCP_TRANSPORT=streamable-http MCP_HOST=0.0.0.0 MCP_PORT=8000 uvx oxylabs-mcp
+```
+
+With the HTTP transport, credentials are passed per request instead of environment variables:
+
+| Credential                | How to pass it                                                                                         |
+|---------------------------|--------------------------------------------------------------------------------------------------------|
+| Web Scraper API           | `Authorization: Basic <base64(username:password)>` (standard HTTP Basic auth)                            |
+| Web Scraper API (alternative) | `X-Oxylabs-Username` and `X-Oxylabs-Password` headers                                                |
+| AI Studio                 | `X-Oxylabs-AI-Studio-Api-Key` header                                                                     |
+
+Example client configuration:
+
+```json
+{
+  "mcpServers": {
+    "oxylabs": {
+      "url": "https://your-host:8000/mcp",
+      "headers": {
+        "Authorization": "Basic <base64 of username:password>",
+        "X-Oxylabs-AI-Studio-Api-Key": "YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+All tools are always listed regardless of provided credentials; calling a tool without the
+credentials it needs returns an error message explaining exactly what to configure.
+
 ### Setup with Claude Desktop
 
 Navigate to **Claude → Settings → Developer → Edit Config** and add one of the configurations above to the `claude_desktop_config.json` file.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oxylabs-mcp"
-version = "0.8.1"
+version = "0.9.0"
 description = "Oxylabs MCP server"
 authors = [
     {name="Augis Braziunas", email="augis.braziunas@oxylabs.io"},

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/oxylabs/oxylabs-mcp",
     "source": "github"
   },
-  "version": "0.8.1",
+  "version": "0.9.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "oxylabs-mcp",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/oxylabs_mcp/__init__.py
+++ b/src/oxylabs_mcp/__init__.py
@@ -1,36 +1,14 @@
 import logging
 from typing import Any
 
-from fastmcp import Context, FastMCP
-from mcp.types import ListToolsRequest, ListToolsResult
+from fastmcp import FastMCP
 
 from oxylabs_mcp.config import settings
-from oxylabs_mcp.tools.ai_studio import AI_TOOLS
 from oxylabs_mcp.tools.ai_studio import mcp as ai_studio_mcp
-from oxylabs_mcp.tools.scraper import SCRAPER_TOOLS
 from oxylabs_mcp.tools.scraper import mcp as scraper_mcp
-from oxylabs_mcp.utils import get_oxylabs_ai_studio_api_key, get_oxylabs_auth
 
 
-class OxylabsMCPServer(FastMCP):
-    """Oxylabs MCP server."""
-
-    async def _list_tools_mcp(self, _: ListToolsRequest) -> ListToolsResult:
-        """List all available Oxylabs tools."""
-        async with Context(fastmcp=self):
-            tools = list(await self._list_tools())
-
-            username, password = get_oxylabs_auth()
-            if not username or not password:
-                tools = [tool for tool in tools if tool.name not in SCRAPER_TOOLS]
-
-            if not get_oxylabs_ai_studio_api_key():
-                tools = [tool for tool in tools if tool.name not in AI_TOOLS]
-
-            return ListToolsResult(tools=[tool.to_mcp_tool(name=tool.name) for tool in tools])
-
-
-mcp = OxylabsMCPServer("oxylabs_mcp")
+mcp = FastMCP("oxylabs_mcp")
 
 mcp.mount(ai_studio_mcp)
 mcp.mount(scraper_mcp)

--- a/src/oxylabs_mcp/utils.py
+++ b/src/oxylabs_mcp/utils.py
@@ -1,3 +1,5 @@
+import base64
+import binascii
 import json
 import logging
 import os
@@ -34,13 +36,45 @@ USERNAME_ENV = "OXYLABS_USERNAME"
 PASSWORD_ENV = "OXYLABS_PASSWORD"  # noqa: S105  # nosec
 AI_STUDIO_API_KEY_ENV = "OXYLABS_AI_STUDIO_API_KEY"
 
-USERNAME_HEADER = "X-Oxylabs-Username"
-PASSWORD_HEADER = "X-Oxylabs-Password"  # noqa: S105  # nosec
-AI_STUDIO_API_KEY_HEADER = "X-Oxylabs-AI-Studio-Api-Key"
+AUTHORIZATION_HEADER = "authorization"
 
-USERNAME_QUERY_PARAM = "oxylabsUsername"
-PASSWORD_QUERY_PARAM = "oxylabsPassword"  # noqa: S105  # nosec
-AI_STUDIO_API_KEY_QUERY_PARAM = "oxylabsAiStudioApiKey"
+# Header pairs accepted for Web Scraper API credentials, in priority order.
+# The X-Oxylabs-* pair is the documented one; the underscore pair is kept for
+# compatibility with clients configured against older deployments.
+CREDENTIAL_HEADER_PAIRS = (
+    ("x-oxylabs-username", "x-oxylabs-password"),
+    ("oxylabs_username", "oxylabs_password"),
+)
+
+# Headers accepted for the AI Studio API key, in priority order.
+AI_STUDIO_API_KEY_HEADERS = (
+    "x-oxylabs-ai-studio-api-key",
+    "oxylabs_ai_studio_api_key",
+)
+
+SCRAPER_CREDENTIALS_MISSING_HTTP = (
+    "Oxylabs Web Scraper API credentials are not provided. "
+    "Pass an 'Authorization: Basic <base64(username:password)>' header, "
+    "or 'X-Oxylabs-Username' and 'X-Oxylabs-Password' headers. "
+    "Get credentials at https://dashboard.oxylabs.io/"
+)
+SCRAPER_CREDENTIALS_MISSING_STDIO = (
+    "Oxylabs Web Scraper API credentials are not provided. "
+    "Set the OXYLABS_USERNAME and OXYLABS_PASSWORD environment variables "
+    "in the MCP server configuration. "
+    "Get credentials at https://dashboard.oxylabs.io/"
+)
+AI_STUDIO_API_KEY_MISSING_HTTP = (
+    "Oxylabs AI Studio API key is not provided. "
+    "Pass an 'X-Oxylabs-AI-Studio-Api-Key' header. "
+    "Get your API key at https://aistudio.oxylabs.io/settings/api-key"
+)
+AI_STUDIO_API_KEY_MISSING_STDIO = (
+    "Oxylabs AI Studio API key is not provided. "
+    "Set the OXYLABS_AI_STUDIO_API_KEY environment variable "
+    "in the MCP server configuration. "
+    "Get your API key at https://aistudio.oxylabs.io/settings/api-key"
+)
 
 
 def clean_html(html: str) -> str:
@@ -167,35 +201,64 @@ class _OxylabsClientWrapper:
         return response_json
 
 
+def _parse_basic_auth(header_value: str) -> tuple[str | None, str | None]:
+    """Parse an 'Authorization: Basic <credentials>' header value."""
+    scheme, _, encoded = header_value.strip().partition(" ")
+    if scheme.lower() != "basic" or not encoded:
+        return None, None
+
+    try:
+        decoded = base64.b64decode(encoded.strip(), validate=True).decode()
+    except (binascii.Error, UnicodeDecodeError):
+        return None, None
+
+    username, separator, password = decoded.partition(":")
+    if not separator:
+        return None, None
+
+    return username or None, password or None
+
+
 def get_oxylabs_auth() -> tuple[str | None, str | None]:
-    """Extract the Oxylabs credentials."""
+    """Extract the Oxylabs Web Scraper API credentials.
+
+    With the HTTP transport, credentials are read from the request headers:
+    the standard 'Authorization: Basic' header first, then the documented
+    'X-Oxylabs-Username'/'X-Oxylabs-Password' pair, then the legacy
+    underscore pair. With the stdio transport, credentials are read from
+    the environment.
+    """
     if settings.MCP_TRANSPORT == "streamable-http":
         request_headers = dict(get_context().request_context.request.headers)  # type: ignore[union-attr]
-        username = request_headers.get(USERNAME_HEADER.lower())
-        password = request_headers.get(PASSWORD_HEADER.lower())
-        if not username or not password:
-            query_params = get_context().request_context.request.query_params  # type: ignore[union-attr]
-            username = query_params.get(USERNAME_QUERY_PARAM)
-            password = query_params.get(PASSWORD_QUERY_PARAM)
-    else:
-        username = os.environ.get(USERNAME_ENV)
-        password = os.environ.get(PASSWORD_ENV)
 
-    return username, password
+        if authorization := request_headers.get(AUTHORIZATION_HEADER):
+            username, password = _parse_basic_auth(authorization)
+            if username and password:
+                return username, password
+
+        for username_header, password_header in CREDENTIAL_HEADER_PAIRS:
+            username = request_headers.get(username_header)
+            password = request_headers.get(password_header)
+            if username and password:
+                return username, password
+
+        return None, None
+
+    return os.environ.get(USERNAME_ENV), os.environ.get(PASSWORD_ENV)
 
 
 def get_oxylabs_ai_studio_api_key() -> str | None:
     """Extract the Oxylabs AI Studio API key."""
     if settings.MCP_TRANSPORT == "streamable-http":
-        request_headers = dict(get_context().request_context.request.headers)  # type: ignore[union-attr]
-        ai_studio_api_key = request_headers.get(AI_STUDIO_API_KEY_HEADER.lower())
-        if not ai_studio_api_key:
-            query_params = get_context().request_context.request.query_params  # type: ignore[union-attr]
-            ai_studio_api_key = query_params.get(AI_STUDIO_API_KEY_QUERY_PARAM)
-    else:
-        ai_studio_api_key = os.getenv(AI_STUDIO_API_KEY_ENV)
+        request_headers: dict[str, str] = dict(
+            get_context().request_context.request.headers  # type: ignore[union-attr]
+        )
+        for header in AI_STUDIO_API_KEY_HEADERS:
+            if ai_studio_api_key := request_headers.get(header):
+                return ai_studio_api_key
+        return None
 
-    return ai_studio_api_key
+    return os.getenv(AI_STUDIO_API_KEY_ENV)
 
 
 @asynccontextmanager
@@ -206,7 +269,9 @@ async def oxylabs_client() -> AsyncIterator[_OxylabsClientWrapper]:
     username, password = get_oxylabs_auth()
 
     if not username or not password:
-        raise ValueError("Oxylabs username and password must be set.")
+        if settings.MCP_TRANSPORT == "streamable-http":
+            raise ValueError(SCRAPER_CREDENTIALS_MISSING_HTTP)
+        raise ValueError(SCRAPER_CREDENTIALS_MISSING_STDIO)
 
     auth = BasicAuth(username=username, password=password)
 
@@ -229,15 +294,21 @@ async def oxylabs_client() -> AsyncIterator[_OxylabsClientWrapper]:
 
 
 def get_and_verify_oxylabs_ai_studio_api_key() -> str:
-    """Extract and varify the Oxylabs AI Studio API key."""
+    """Extract and verify the Oxylabs AI Studio API key."""
     ai_studio_api_key = get_oxylabs_ai_studio_api_key()
 
     if ai_studio_api_key is None:
-        msg = "AI Studio API key is not set"
+        if settings.MCP_TRANSPORT == "streamable-http":
+            msg = AI_STUDIO_API_KEY_MISSING_HTTP
+        else:
+            msg = AI_STUDIO_API_KEY_MISSING_STDIO
         logger.warning(msg)
         raise ValueError(msg)
     if not is_api_key_valid(ai_studio_api_key):
-        raise ValueError("AI Studio API key is not valid")
+        raise ValueError(
+            "The provided Oxylabs AI Studio API key is not valid. "
+            "Check your API key at https://aistudio.oxylabs.io/settings/api-key"
+        )
 
     return ai_studio_api_key
 

--- a/tests/integration/test_server.py
+++ b/tests/integration/test_server.py
@@ -1,14 +1,19 @@
+import base64
 import json
 import re
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from fastmcp import FastMCP
+from fastmcp import Client, FastMCP
 from httpx import HTTPStatusError, Request, RequestError, Response
-from mcp.types import ListToolsRequest
 
+from oxylabs_mcp import utils
 from oxylabs_mcp.config import settings
 from tests.integration import params
+
+
+def _basic_auth(username: str, password: str) -> str:
+    return "Basic " + base64.b64encode(f"{username}:{password}".encode()).decode()
 
 
 @pytest.mark.asyncio
@@ -134,5 +139,101 @@ async def test_request_client_error_handling(
 @pytest.mark.parametrize("transport", ["stdio", "streamable-http"])
 async def test_list_tools(mcp: FastMCP, transport: str):
     settings.MCP_TRANSPORT = transport
-    result = await mcp._list_tools_mcp(ListToolsRequest())
-    assert len(result.tools) == 10
+    try:
+        async with Client(mcp) as client:
+            tools = await client.list_tools()
+        assert len(tools) == 10
+    finally:
+        settings.MCP_TRANSPORT = "stdio"
+
+
+@pytest.mark.parametrize(
+    ("headers", "expected"),
+    [
+        pytest.param(
+            {"authorization": _basic_auth("basic_user", "basic_pass")},
+            ("basic_user", "basic_pass"),
+            id="authorization_basic",
+        ),
+        pytest.param(
+            {"x-oxylabs-username": "dash_user", "x-oxylabs-password": "dash_pass"},
+            ("dash_user", "dash_pass"),
+            id="documented_headers",
+        ),
+        pytest.param(
+            {"oxylabs_username": "legacy_user", "oxylabs_password": "legacy_pass"},
+            ("legacy_user", "legacy_pass"),
+            id="legacy_underscore_headers",
+        ),
+        pytest.param(
+            {
+                "authorization": _basic_auth("basic_user", "basic_pass"),
+                "x-oxylabs-username": "dash_user",
+                "x-oxylabs-password": "dash_pass",
+            },
+            ("basic_user", "basic_pass"),
+            id="authorization_basic_takes_priority",
+        ),
+        pytest.param(
+            {"authorization": "Bearer some-token"},
+            (None, None),
+            id="non_basic_authorization_is_ignored",
+        ),
+        pytest.param(
+            {"authorization": "Basic not-base64!"},
+            (None, None),
+            id="malformed_basic_credentials_are_ignored",
+        ),
+        pytest.param({}, (None, None), id="no_credentials"),
+    ],
+)
+def test_get_oxylabs_auth_with_http_transport(request_context, headers, expected):
+    settings.MCP_TRANSPORT = "streamable-http"
+    try:
+        request_context.request_context.request.headers = headers
+        assert utils.get_oxylabs_auth() == expected
+    finally:
+        settings.MCP_TRANSPORT = "stdio"
+
+
+@pytest.mark.parametrize(
+    ("headers", "expected"),
+    [
+        pytest.param(
+            {"x-oxylabs-ai-studio-api-key": "dash_key"},
+            "dash_key",
+            id="documented_header",
+        ),
+        pytest.param(
+            {"oxylabs_ai_studio_api_key": "legacy_key"},
+            "legacy_key",
+            id="legacy_underscore_header",
+        ),
+        pytest.param({}, None, id="no_api_key"),
+    ],
+)
+def test_get_oxylabs_ai_studio_api_key_with_http_transport(request_context, headers, expected):
+    settings.MCP_TRANSPORT = "streamable-http"
+    try:
+        request_context.request_context.request.headers = headers
+        assert utils.get_oxylabs_ai_studio_api_key() == expected
+    finally:
+        settings.MCP_TRANSPORT = "stdio"
+
+
+@pytest.mark.asyncio
+async def test_scraper_tool_without_credentials_returns_actionable_error(
+    mcp: FastMCP,
+    request_context,
+    oxylabs_client: AsyncMock,
+):
+    settings.MCP_TRANSPORT = "streamable-http"
+    try:
+        request_context.request_context.request.headers = {}
+
+        with pytest.raises(Exception, match="dashboard.oxylabs.io") as exc_info:
+            await mcp.call_tool("universal_scraper", arguments={"url": "test_url"})
+
+        assert "Authorization" in str(exc_info.value)
+    finally:
+        settings.MCP_TRANSPORT = "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -1272,7 +1272,7 @@ wheels = [
 
 [[package]]
 name = "oxylabs-mcp"
-version = "0.8.1"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
- Accept standard 'Authorization: Basic' for Web Scraper API credentials on the HTTP transport, alongside the documented X-Oxylabs-* headers and the legacy underscore header names used by existing deployments
- Remove credentials-in-query-params support: URLs are logged by proxies and access logs, so secrets must not travel in them
- Always list all tools regardless of credentials; a tool called without its credentials now returns an actionable error naming the exact header or environment variable to set and where to get the credential
- Document the streamable-http transport and its auth contract in README
- Bump version to 0.9.0