### PR TITLE
Advertise the hosted endpoint in the MCP registry and automate publis…

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -56,3 +56,47 @@ jobs:
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}
+
+  publish-to-mcp-registry:
+    name: Publish server.json to the official MCP registry
+    runs-on: ubuntu-latest
+    needs: build-n-publish
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Check for registry signing key
+      id: key
+      run: |
+        if [ -n "${{ secrets.MCP_REGISTRY_PRIVATE_KEY }}" ]; then
+          echo "present=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "present=false" >> "$GITHUB_OUTPUT"
+          echo "::warning::MCP_REGISTRY_PRIVATE_KEY secret is not set; skipping MCP registry publish"
+        fi
+
+    - name: Wait for PyPI to serve the new version
+      if: steps.key.outputs.present == 'true'
+      run: |
+        VERSION="${GITHUB_REF_NAME#v}"
+        for i in $(seq 1 30); do
+          if curl -sf "https://pypi.org/pypi/oxylabs-mcp/$VERSION/json" > /dev/null; then
+            echo "PyPI serves $VERSION"
+            exit 0
+          fi
+          sleep 10
+        done
+        echo "PyPI never served $VERSION" >&2
+        exit 1
+
+    - name: Install mcp-publisher
+      if: steps.key.outputs.present == 'true'
+      run: |
+        curl -sL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" \
+          | tar xz mcp-publisher
+        sudo mv mcp-publisher /usr/local/bin/
+
+    - name: Publish to MCP registry
+      if: steps.key.outputs.present == 'true'
+      run: |
+        mcp-publisher login dns --domain oxylabs.io --private-key "${{ secrets.MCP_REGISTRY_PRIVATE_KEY }}"
+        mcp-publisher publish

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oxylabs-mcp"
-version = "0.9.0"
+version = "0.9.1"
 description = "Oxylabs MCP server"
 authors = [
     {name="Augis Braziunas", email="augis.braziunas@oxylabs.io"},

--- a/server.json
+++ b/server.json
@@ -6,12 +6,33 @@
     "url": "https://github.com/oxylabs/oxylabs-mcp",
     "source": "github"
   },
-  "version": "0.9.0",
+  "websiteUrl": "https://oxylabs.io",
+  "version": "0.9.1",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.oxylabs.io/mcp",
+      "headers": [
+        {
+          "description": "HTTP Basic auth with your Oxylabs Web Scraper API username and password: 'Basic <base64(username:password)>'",
+          "isRequired": false,
+          "isSecret": true,
+          "name": "Authorization"
+        },
+        {
+          "description": "Your Oxylabs AI Studio API key",
+          "isRequired": false,
+          "isSecret": true,
+          "name": "X-Oxylabs-AI-Studio-Api-Key"
+        }
+      ]
+    }
+  ],
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "oxylabs-mcp",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "transport": {
         "type": "stdio"
       },

--- a/uv.lock
+++ b/uv.lock
@@ -1272,7 +1272,7 @@ wheels = [
 
 [[package]]
 name = "oxylabs-mcp"
-version = "0.9.0"
+version = "0.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
…hing

- server.json: add the mcp.oxylabs.io remote (streamable-http, Basic auth or AI Studio key header) and websiteUrl; bump to 0.9.1
- Ship a py.typed marker so downstream consumers can type-check against this package
- Add a publish-to-mcp-registry job to the release workflow: after the PyPI publish succeeds it logs in with the DNS-verified signing key (MCP_REGISTRY_PRIVATE_KEY secret) and publishes server.json; skips with a warning when the secret is absent