### PR TITLE
Add glama.json to enable claiming the Glama listing

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "oxylabs-mcp-bot",
+    "oxy-giedrius"
+  ]
+}


### PR DESCRIPTION
Glama requires org-owned server pages to declare maintainer GitHub accounts in a glama.json at the repo root before they can be claimed. Lists the company service account and the current maintainer.