### PR TITLE
Fix the pages parameter: return every page, not just the first

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oxylabs-mcp"
-version = "0.9.2"
+version = "0.9.3"
 description = "Oxylabs MCP server"
 authors = [
     {name="Augis Braziunas", email="augis.braziunas@oxylabs.io"},

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "source": "github"
   },
   "websiteUrl": "https://oxylabs.io",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "remotes": [
     {
       "type": "streamable-http",
@@ -32,7 +32,7 @@
     {
       "registryType": "pypi",
       "identifier": "oxylabs-mcp",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "transport": {
         "type": "stdio"
       },

--- a/src/oxylabs_mcp/utils.py
+++ b/src/oxylabs_mcp/utils.py
@@ -356,14 +356,12 @@ def extract_links_with_text(html: str, base_url: str | None = None) -> list[str]
     return links
 
 
-def get_content(
-    response_json: dict[str, typing.Any],
+def _render_content(
+    content: str | dict[str, typing.Any],
     *,
     output_format: str | None,
-    parse: bool = False,
+    parse: bool,
 ) -> str:
-    """Extract content from response and convert to a proper format."""
-    content = response_json["results"][0]["content"]
     if parse and isinstance(content, dict):
         return json.dumps(content)
     if output_format == "html":
@@ -374,3 +372,32 @@ def get_content(
 
     stripped_html = clean_html(str(content))
     return markdownify(stripped_html)
+
+
+def get_content(
+    response_json: dict[str, typing.Any],
+    *,
+    output_format: str | None,
+    parse: bool = False,
+) -> str:
+    """Extract content from response and convert to a proper format.
+
+    A paginated request (`pages` > 1) returns one entry in `results` per page;
+    every page is included in the output. Single-page responses keep the same
+    output shape as before.
+    """
+    results = response_json["results"]
+    contents = [result["content"] for result in results]
+
+    if len(contents) == 1:
+        return _render_content(contents[0], output_format=output_format, parse=parse)
+
+    if parse and all(isinstance(content, dict) for content in contents):
+        return json.dumps(contents)
+
+    rendered_pages = (
+        _render_content(content, output_format=output_format, parse=parse) for content in contents
+    )
+    return "\n\n".join(
+        f"<!-- Page {number} -->\n{page}" for number, page in enumerate(rendered_pages, start=1)
+    )

--- a/tests/integration/params.py
+++ b/tests/integration/params.py
@@ -23,6 +23,18 @@ AI_STUDIO_JSON_RESPONSE = {
     "results": [{"content": {"data": "value"}}],
     "job": JOB_RESPONSE,
 }
+# A paginated request (pages > 1) returns one entry in `results` per page.
+MULTI_PAGE_STR_RESPONSE = {
+    "results": [{"content": "Mocked content page 1"}, {"content": "Mocked content page 2"}],
+    "job": JOB_RESPONSE,
+}
+MULTI_PAGE_JSON_RESPONSE = {
+    "results": [
+        {"content": {"page": 1, "data": "value1"}},
+        {"content": {"page": 2, "data": "value2"}},
+    ],
+    "job": JOB_RESPONSE,
+}
 
 QUERY_ONLY = pytest.param(
     {"query": "Generic query"},

--- a/tests/integration/test_server.py
+++ b/tests/integration/test_server.py
@@ -231,6 +231,63 @@ def test_get_oxylabs_ai_studio_api_key_with_http_transport(request_context, head
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("tool", ["google_search_scraper", "amazon_search_scraper"])
+async def test_paginated_parsed_response_returns_all_pages(
+    mcp: FastMCP,
+    request_data: Request,
+    oxylabs_client: AsyncMock,
+    tool: str,
+):
+    mock_response = Response(
+        200, content=json.dumps(params.MULTI_PAGE_JSON_RESPONSE), request=request_data
+    )
+    oxylabs_client.post.return_value = mock_response
+
+    result = await mcp.call_tool(tool, arguments={"query": "Generic query", "pages": 2})
+
+    payload = json.loads(result.content[0].text)
+    assert payload == [{"page": 1, "data": "value1"}, {"page": 2, "data": "value2"}]
+
+
+@pytest.mark.asyncio
+async def test_paginated_unparsed_response_includes_every_page(
+    mcp: FastMCP,
+    request_data: Request,
+    oxylabs_client: AsyncMock,
+):
+    mock_response = Response(
+        200, content=json.dumps(params.MULTI_PAGE_STR_RESPONSE), request=request_data
+    )
+    oxylabs_client.post.return_value = mock_response
+
+    result = await mcp.call_tool(
+        "google_search_scraper",
+        arguments={"query": "Generic query", "pages": 2, "parse": False},
+    )
+
+    text = result.content[0].text
+    assert "Mocked content page 1" in text
+    assert "Mocked content page 2" in text
+    assert "<!-- Page 1 -->" in text
+    assert "<!-- Page 2 -->" in text
+
+
+@pytest.mark.asyncio
+async def test_single_page_response_shape_is_unchanged(
+    mcp: FastMCP,
+    request_data: Request,
+    oxylabs_client: AsyncMock,
+):
+    mock_response = Response(200, content=json.dumps(params.JSON_RESPONSE), request=request_data)
+    oxylabs_client.post.return_value = mock_response
+
+    result = await mcp.call_tool("google_search_scraper", arguments={"query": "Generic query"})
+
+    # A single page stays a bare object, not a one-element array.
+    assert json.loads(result.content[0].text) == {"data": "value"}
+
+
+@pytest.mark.asyncio
 async def test_scraper_tool_without_credentials_returns_actionable_error(
     mcp: FastMCP,
     request_context,

--- a/uv.lock
+++ b/uv.lock
@@ -1446,7 +1446,7 @@ wheels = [
 
 [[package]]
 name = "oxylabs-mcp"
-version = "0.9.2"
+version = "0.9.3"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
google_search_scraper and amazon_search_scraper accept pages/start_page, and the Web Scraper API bills and returns one entry in results[] per page - but get_content() was hardcoded to results[0], silently dropping every page after the first. Users paid for pages they never received.

- get_content() now renders every entry in results: parsed content becomes a JSON array of per-page objects, other formats are joined with page-comment separators
- Single-page responses keep the exact same output shape as before
- Multi-page fixtures and tests for parsed, unparsed, and single-page shapes (the whole suite previously used only single-result fixtures, which is why this went unnoticed)
- Bump to 0.9.3

Verified live: google_search_scraper with pages=2 returns both pages through the real Web Scraper API.

Reported by an external agent developer via the content team.